### PR TITLE
Added IMAP_PATH option with 'inbox' as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The matching keyword (`support`, `dev`) is **removed** from the task title.
 | `VIKUNJA_API_URL`  | `https://vikunja.example.com/api/v1`           | Base URL for the Vikunja API |
 | `VIKUNJA_TOKEN`    | `your-bearer-token`                            | Personal access token from Vikunja |
 | `PROJECT_MAPPING`  | `'{"support": "3", "dev": "7"}'`               | JSON object mapping subject keywords to project IDs |
+| `IMAP_FOLDER`      | `inbox/todo`                                   | optional: IMAP Path to folder, default is `inbox` |
 
 > 🔹 **What is a Vikunja Project ID?**  
 > You can find it by opening a project in Vikunja and checking the URL:  
@@ -55,6 +56,7 @@ docker run -d \
   -e VIKUNJA_API_URL=https://vikunja.example.com/api/v1 \
   -e VIKUNJA_TOKEN=your-vikunja-token \
   -e PROJECT_MAPPING='{"support": "3", "dev": "7"}' \
+  -e IMAP_FOLDER='inbox' \
   --restart unless-stopped \
   weselinka/vikunja-mail-parser
 ```
@@ -77,6 +79,7 @@ services:
       VIKUNJA_API_URL: https://vikunja.example.com/api/v1
       VIKUNJA_TOKEN: your-vikunja-token
       PROJECT_MAPPING: '{"support": "3", "dev": "7"}'
+      IMAP_FOLDER: 'inbox'
     restart: unless-stopped
 ```
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,5 @@ services:
       VIKUNJA_API_URL: https://my.vikunjaurl.com/api/v1
       VIKUNJA_TOKEN: vikunja_token
       PROJECT_MAPPING: '{"STRING_FOR_EMAIL_SUBJECT": "PROJECT_ID", "STRING_FOR_EMAIL_SUBJECT": "PROJECT_ID"}'
+      IMAP_PATH: 'inbox'
     restart: unless-stopped

--- a/mail_parser.py
+++ b/mail_parser.py
@@ -24,6 +24,15 @@ else:
     print("No Projects mapped, check config of env")
     PROJECT_MAPPING = {}
 
+# Load IMAP_PATH from environment variables
+imap_path_str = os.getenv('IMAP_PATH')
+
+# If IMAP_PATH is defined, parse it; otherwise, use an empty string
+if imap_path_str:    
+    IMAP_PATH = imap_path_str
+else:    
+    IMAP_PATH = "inbox"
+
 ATTACHMENT_DIR = 'attachments'
 
 # Ensure attachment directory exists
@@ -32,7 +41,7 @@ os.makedirs(ATTACHMENT_DIR, exist_ok=True)
 def connect_to_email():
     mail = imaplib.IMAP4_SSL(IMAP_SERVER)
     mail.login(EMAIL_ACCOUNT, EMAIL_PASSWORD)
-    mail.select("inbox")
+    mail.select(IMAP_PATH)
     return mail
 
 def fetch_unread_emails(mail):
@@ -102,6 +111,7 @@ def create_vikunja_task(project_id, title, description):
         "title": title,
         "description": description,
     }
+    print(payload)
     response = requests.put(url, json=payload, headers=headers)
     if response.status_code == 201:
         print(f"Task '{title}' created successfully in project ID {project_id}.")

--- a/mail_parser.py
+++ b/mail_parser.py
@@ -17,15 +17,15 @@ VIKUNJA_TOKEN = os.getenv('VIKUNJA_TOKEN')
 # Load PROJECT_MAPPING from environment variables
 project_mapping_str = os.getenv('PROJECT_MAPPING')
 
+# Load IMAP_PATH from environment variables
+imap_path_str = os.getenv('IMAP_PATH')
+
 # If PROJECT_MAPPING is defined, parse it; otherwise, use an empty dictionary
 if project_mapping_str:
     PROJECT_MAPPING = json.loads(project_mapping_str)
 else:
     print("No Projects mapped, check config of env")
     PROJECT_MAPPING = {}
-
-# Load IMAP_PATH from environment variables
-imap_path_str = os.getenv('IMAP_PATH')
 
 # If IMAP_PATH is defined, parse it; otherwise, use an empty string
 if imap_path_str:    
@@ -111,7 +111,7 @@ def create_vikunja_task(project_id, title, description):
         "title": title,
         "description": description,
     }
-    print(payload)
+
     response = requests.put(url, json=payload, headers=headers)
     if response.status_code == 201:
         print(f"Task '{title}' created successfully in project ID {project_id}.")


### PR DESCRIPTION
I updated the script to use an IMAP_PATH if configured to find where it needs to scan for mail.

This fits my use case where I have a dedicated email address for todo@domain.com mapped to a subfolder off my main account, keeping things tidy.